### PR TITLE
Fixed sending messages after the logout started but not completed

### DIFF
--- a/FixAntenna/NetCore/FixEngine/Session/IoThreads/NoQueueMessagePumper.cs
+++ b/FixAntenna/NetCore/FixEngine/Session/IoThreads/NoQueueMessagePumper.cs
@@ -299,7 +299,7 @@ namespace Epam.FixAntenna.NetCore.FixEngine.Session.IoThreads
 		{
 			if (_started)
 			{
-				return SerializeAndSend(msgType, content, null, true);
+				return SerializeAndSend(msgType, content, null, false);
 			}
 
 			return PutInQueue(msgType, content);
@@ -307,9 +307,17 @@ namespace Epam.FixAntenna.NetCore.FixEngine.Session.IoThreads
 
 		private bool SerializeAndSend(string msgType, FixMessage content, ChangesType? changesType, bool checkState)
 		{
-			if (checkState && !_started)
+			if (checkState)
 			{
-				throw new InvalidOperationException("Pumper is not started, it cannot send any messages in this state.");
+				if (!_started)
+				{
+					throw new InvalidOperationException("Pumper is not started, it cannot send any messages in this state.");
+				}
+
+				if (((AbstractFixSession)_fixSession).AlreadySendingLogout)
+				{
+					throw new InvalidOperationException("Session is shutting down, cannot send any messages in this state.");
+				}
 			}
 			try
 			{

--- a/Tests/Core.Tests/FixEngine/Session/IoThreads/NoQueueMessagePumperTest.cs
+++ b/Tests/Core.Tests/FixEngine/Session/IoThreads/NoQueueMessagePumperTest.cs
@@ -24,7 +24,7 @@ using NUnit.Framework;
 
 namespace Epam.FixAntenna.NetCore.FixEngine.Session.IOThreads
 {
-    [TestFixture]
+	[TestFixture]
 	internal class NoQueueMessagePumperTest
 	{
 		private NoQueueMessagePumper _messagePumper;
@@ -67,6 +67,9 @@ namespace Epam.FixAntenna.NetCore.FixEngine.Session.IOThreads
 		[Test]
 		public virtual void WriteInButch()
 		{
+			// test session has AlreadySendingLogout = true while not inited
+			_extendedFixSession.AlreadySendingLogout.AtomicExchange(false);
+
 			_messagePumper.Start();
 			for (var i = 0; i < 5; i++)
 			{


### PR DESCRIPTION
Fixed: NoQueueMessagePumper was able to send application messages after the logout initiated