### PR TITLE
Add ITcpListenerFactory to allow creating custom tcp listener

### DIFF
--- a/FixAntenna/NetCore/FixEngine/FixServer.cs
+++ b/FixAntenna/NetCore/FixEngine/FixServer.cs
@@ -31,7 +31,7 @@ namespace Epam.FixAntenna.NetCore.FixEngine
 	/// </summary>
 	public class FixServer
 	{
-        public ITcpListenerFactory TcpListenerFactory {get; set;} = new DefaultTcpListenerFactory();
+		public ITcpListenerFactory TcpListenerFactory { get; set; } = new DefaultTcpListenerFactory();
 
 		private static readonly ILog Log = LogFactory.GetLog(typeof(FixServer));
 

--- a/FixAntenna/NetCore/FixEngine/FixServer.cs
+++ b/FixAntenna/NetCore/FixEngine/FixServer.cs
@@ -16,6 +16,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net.Sockets;
 using Epam.FixAntenna.NetCore.Common.Logging;
 using Epam.FixAntenna.NetCore.Configuration;
 using Epam.FixAntenna.NetCore.FixEngine.Acceptor;
@@ -31,6 +32,8 @@ namespace Epam.FixAntenna.NetCore.FixEngine
 	/// </summary>
 	public class FixServer
 	{
+        public ITcpListenerFactory TcpListenerFactory {get; set;} = new DefaultTcpListenerFactory();
+
 		private static readonly ILog Log = LogFactory.GetLog(typeof(FixServer));
 
 		private readonly IConnectionHandler _connectionHandler;
@@ -201,11 +204,11 @@ namespace Epam.FixAntenna.NetCore.FixEngine
 				if (_servers.ContainsKey(port))
 				{
 					Log.Warn($"Server on port {port} has been configured already. Configuration will be overriden.");
-					_servers[port] = new TcpServer(Nic, port, ConfigAdapter);
+					_servers[port] = new TcpServer(Nic, port, ConfigAdapter, TcpListenerFactory);
 				}
 				else
 				{
-					_servers.Add(port, new TcpServer(Nic, port, ConfigAdapter));
+					_servers.Add(port, new TcpServer(Nic, port, ConfigAdapter, TcpListenerFactory));
 				}
 			}
 		}

--- a/FixAntenna/NetCore/FixEngine/FixServer.cs
+++ b/FixAntenna/NetCore/FixEngine/FixServer.cs
@@ -16,7 +16,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net.Sockets;
 using Epam.FixAntenna.NetCore.Common.Logging;
 using Epam.FixAntenna.NetCore.Configuration;
 using Epam.FixAntenna.NetCore.FixEngine.Acceptor;

--- a/FixAntenna/NetCore/FixEngine/Transport/Server/Tcp/TcpServer.cs
+++ b/FixAntenna/NetCore/FixEngine/Transport/Server/Tcp/TcpServer.cs
@@ -25,24 +25,24 @@ using Epam.FixAntenna.NetCore.FixEngine.Session.Util;
 
 namespace Epam.FixAntenna.NetCore.FixEngine.Transport.Server.Tcp
 {
-    public interface ITcpListenerFactory
-    {
-        TcpListener Create(int port);
-        TcpListener Create(IPAddress port, int i);
-    }
+	public interface ITcpListenerFactory
+	{
+		TcpListener Create(int port);
+		TcpListener Create(IPAddress address, int port);
+	}
 
-    class DefaultTcpListenerFactory : ITcpListenerFactory
-    {
-        public TcpListener Create(int port)
-        {
-            return TcpListener.Create(port);
-        }
-        
-        public TcpListener Create(IPAddress address, int port)
-        {
-            return new TcpListener(address, port);
-        }
-    }
+	class DefaultTcpListenerFactory : ITcpListenerFactory
+	{
+		public TcpListener Create(int port)
+		{
+			return TcpListener.Create(port);
+		}
+
+		public TcpListener Create(IPAddress address, int port)
+		{
+			return new TcpListener(address, port);
+		}
+	}
 
 	/// <summary>
 	/// TCP server implementation.
@@ -52,7 +52,7 @@ namespace Epam.FixAntenna.NetCore.FixEngine.Transport.Server.Tcp
 		private static ILog _log = LogFactory.GetLog(typeof(TcpServer));
 		private IConnectionListener _listener;
 		private TcpListener _serverSocket;
-        private ITcpListenerFactory _tcpListenerFactory;
+		private ITcpListenerFactory _tcpListenerFactory;
 		private ConfigurationAdapter _confAdapter;
 
 		private object _lock = new object();
@@ -76,7 +76,7 @@ namespace Epam.FixAntenna.NetCore.FixEngine.Transport.Server.Tcp
 		public TcpServer(int port)
 		{
 			_confAdapter = new ConfigurationAdapter(Config.GlobalConfiguration);
-            _tcpListenerFactory = new DefaultTcpListenerFactory();
+			_tcpListenerFactory = new DefaultTcpListenerFactory();
 			Port = port;
 		}
 
@@ -89,7 +89,7 @@ namespace Epam.FixAntenna.NetCore.FixEngine.Transport.Server.Tcp
 		public TcpServer(string host, int port, ConfigurationAdapter configAdapter, ITcpListenerFactory tcpListenerFactory)
 		{
 			_confAdapter = configAdapter;
-            _tcpListenerFactory = tcpListenerFactory;
+			_tcpListenerFactory = tcpListenerFactory;
 			ConnectAddress = host;
 			Port = port;
 		}

--- a/FixAntenna/NetCore/FixEngine/Transport/Server/Tcp/TcpServer.cs
+++ b/FixAntenna/NetCore/FixEngine/Transport/Server/Tcp/TcpServer.cs
@@ -76,7 +76,7 @@ namespace Epam.FixAntenna.NetCore.FixEngine.Transport.Server.Tcp
 		public TcpServer(int port)
 		{
 			_confAdapter = new ConfigurationAdapter(Config.GlobalConfiguration);
-
+            _tcpListenerFactory = new DefaultTcpListenerFactory();
 			Port = port;
 		}
 


### PR DESCRIPTION
## Add ITcpListenerFactory 

### Problem 

Currently, in the `FixServer`, there is no method to inject custom `TcpListener` into the `TcpServer`. 

### Solution 

This PR addresses this issue by introducing a new interface `ITcpListenerFactory` that can be injected into the `TcpServer` constructor, which can be set from the Property `TcpListenerFactory` in public `FixServer` class. This allows us to reuse the `TcpServer` with custom `TcpListener` instead of reinventing  `TcpServer`  by overriding the `Start` method on `FixServer` (or otherwise require changing visibility of many unrelated components)